### PR TITLE
Feature/#22 support for sitemaps

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,6 @@
 module.exports = {
   siteMetadata: {
+    siteUrl: "https://gatsby.wdslab.com",
     organization: {
       name: "WebDevStudios",
       url: "https://gatsby.wdslab.com",
@@ -29,6 +30,7 @@ module.exports = {
       }
     },
     "gatsby-transformer-sharp",
-    "gatsby-plugin-sharp"
+    "gatsby-plugin-sharp",
+    "gatsby-plugin-sitemap"
   ]
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-image": "^2.2.15",
     "gatsby-plugin-react-helmet": "^3.1.5",
     "gatsby-plugin-sharp": "^2.2.18",
+    "gatsby-plugin-sitemap": "^2.2.10",
     "gatsby-source-filesystem": "^2.1.18",
     "gatsby-source-graphql": "^2.1.11",
     "gatsby-transformer-sharp": "^2.2.12",


### PR DESCRIPTION
Closes:
https://github.com/WebDevStudios/gatsby-starter-wordpress-graphql/issues/22

URL is
`/sitemap.xml`

Adds sitemap plugin and required minimal config for `gatsby-config.js`.

Notes:
Not sure if this is redundant with regards to the `url` key under `organization` object, but the sitemap docs say that there should be a `siteUrl` key under `siteMetadata` — it says this is required.

Screenshot
<img width="1279" alt="Screenshot 2019-09-03 11 27 06" src="https://user-images.githubusercontent.com/5550150/64188051-ab143300-ce3f-11e9-99b2-b19da229fed9.png">

Steps for testing
NOTE FROM DOCS:
"This plugin only generates output when run in production mode! To test your sitemap, run: `gatsby build && gatsby serve`"