### PR TITLE
Adds support for GTM code.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,17 @@ module.exports = {
         refetchInterval: 60
       }
     },
+    {
+      resolve: `gatsby-plugin-gtag`,
+      options: {
+        // your google analytics tracking id
+        trackingId: `UA-XXXXXXXX-X`,
+        // Puts tracking script in the head instead of the body
+        head: false,
+        // enable ip anonymization
+        anonymize: true,
+      },
+    },
     "gatsby-transformer-sharp",
     "gatsby-plugin-sharp",
     "gatsby-plugin-sitemap"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "gatsby": "^2.15.7",
     "gatsby-image": "^2.2.17",
+    "gatsby-plugin-gtag": "^1.0.11",
     "gatsby-plugin-react-helmet": "^3.1.6",
     "gatsby-plugin-sharp": "^2.2.19",
     "gatsby-plugin-sitemap": "^2.2.10",


### PR DESCRIPTION
Closes #21 

## Description

I've added the plugin for GTM. Note, since we don't have a GTM code set up, I've used the default placeholder of `UA-XXXXXXXX-X`. We'll just need to add that in when we have it, but the code is there.

## Screenshot

<img width="740" alt="Screenshot 2019-09-09 17 04 35" src="https://user-images.githubusercontent.com/5550150/64566414-f0df6880-d323-11e9-968f-4fceda44db33.png">



## Steps for testing

Run `gatsby build` in order to be able to view full source code. Once the build is done, load up the built site in a browser and confirm the GTM is in source code in the correct place.
